### PR TITLE
Fixes errors caused by system 0.8.7 refactor

### DIFF
--- a/module/action-handler.js
+++ b/module/action-handler.js
@@ -10,7 +10,7 @@ Hooks.once('tokenActionHudCoreApiReady', async (coreModule) => {
      */
     ActionHandler = class ActionHandler extends coreModule.api.ActionHandler {
         dnd4eConfig = CONFIG.DND4E
-        dnd4eTAHApi = game.dnd4e.tokenBarHooks ?? dnd4e.compatibility.tah.TokenBarHooks
+        dnd4eTAHApi = game?.dnd4e?.tokenBarHooks ?? dnd4e.compatibility.tah.TokenBarHooks
         i18n = (str) => coreModule.api.Utils.i18n(str)
         version = this.dnd4eTAHApi.version
 

--- a/module/defaults.js
+++ b/module/defaults.js
@@ -50,9 +50,9 @@ Hooks.once('tokenActionHudCoreApiReady', async (coreModule) => {
     }
 
     // convert the dnd 4e config to a TAH group
-    const inventoryGroups = dndToGroup(game.dnd4e.config.inventoryTypes, "")
-    const featureGroups = dndToGroup(game.dnd4e.config.featureTypes, "Feature")
-    const ritualGroups = dndToGroup(game.dnd4e.config.ritualTypes, "Ritual")
+    const inventoryGroups = dndToGroup(dnd4e.CONFIG.inventoryTypes, "")
+    const featureGroups = dndToGroup(dnd4e.CONFIG.featureTypes, "Feature")
+    const ritualGroups = dndToGroup(dnd4e.CONFIG.ritualTypes, "Ritual")
 
     // Power groups are nested
     /*
@@ -64,7 +64,7 @@ Hooks.once('tokenActionHudCoreApiReady', async (coreModule) => {
         usage: {
      */
     let powerGroupsFlattened = {}
-    Object.values(game.dnd4e.config.powerGroupings).forEach(grouping => {
+    Object.values(dnd4e.CONFIG.powerGroupings).forEach(grouping => {
         for (const [key, value] of Object.entries(grouping)) {
             powerGroupsFlattened[key] = value
         }

--- a/module/init.js
+++ b/module/init.js
@@ -2,7 +2,7 @@ import { SystemManager } from './system-manager.js'
 import { MODULE, REQUIRED_CORE_MODULE_VERSION } from './constants.js'
 
 Hooks.on('tokenActionHudCoreApiReady', async () => {
-    if (game.dnd4e.tokenBarHooks.version < 3 && game.user.isGM) {
+    if (game?.dnd4e?.tokenBarHooks.version < 3 && game.user.isGM) {
         ui.notifications.warn("DRACS TOOLS: Old D&D 4e system detected.  Please upgrade to version <b>0.4.52</b><br>Token Action Hud support for this version is deprecated and will be removed in future.");
     }
 

--- a/module/roll-handler.js
+++ b/module/roll-handler.js
@@ -5,7 +5,7 @@ Hooks.once('tokenActionHudCoreApiReady', async (coreModule) => {
      * Extends Token Action HUD Core's RollHandler class and handles action events triggered when an action is clicked
      */
     RollHandler = class RollHandler extends coreModule.api.RollHandler {
-        dnd4eTAHApi = game.dnd4e.tokenBarHooks ?? dnd4e.compatibility.tah.TokenBarHooks
+        dnd4eTAHApi = game?.dnd4e?.tokenBarHooks ?? dnd4e.compatibility.tah.TokenBarHooks
 
         /**
          * Handle action click


### PR DESCRIPTION
The references to old `game.dnd4e.tokenBarHooks` still cause an error when it no longer exists. `?`  appears to make everything work as intended. This shouldn't compromise the backwards compatibility.

However, 0.9.7 also broke references to `game.dnd4e.config` (needs to be `dnd4e.CONFIG` now). This probably _does_ compromise backwards compatibility, so feel free to ignore this and make a similarly modal solution if you prefer!

